### PR TITLE
Build with oldest numpy available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,16 +53,24 @@ matrix:
     - os:        linux
       env:
         - MB_PYTHON_VERSION=3.7
+        - NP_BUILD_DEP=numpy==1.14.5
+        - NP_TEST_DEP=numpy==1.14.5
     - os:        linux
       env:
         - MB_PYTHON_VERSION=3.7
         - PLAT=i686
+        - NP_BUILD_DEP=numpy==1.14.5
+        - NP_TEST_DEP=numpy==1.14.5
     - os:        linux
       env:
         - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP=numpy==1.17.3
+        - NP_TEST_DEP=numpy==1.17.3
     - os:        linux
       env:
         - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP=numpy==1.17.3
+        - NP_TEST_DEP=numpy==1.17.3
         - PLAT=i686
     # OSX
     - os:        osx
@@ -77,12 +85,18 @@ matrix:
       language:  generic
       env:
         - MB_PYTHON_VERSION=3.7
+        - NP_BUILD_DEP=numpy==1.14.5
+        - NP_TEST_DEP=numpy==1.14.5
     - os:        osx
       language:  generic
       env:
         - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP=numpy==1.17.3
+        - NP_TEST_DEP=numpy==1.17.3
 
 before_install:
+    - BUILD_DEPENDS="$BUILD_DEPENDS $NP_BUILD_DEP"
+    - TEST_DEPENDS="$TEST_DEPENDS $NP_TEST_DEP
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,12 @@ env:
         # Build against older version of Numpy supported
         - NP_BUILD_DEP="numpy==1.13.3"
         - NP_TEST_DEP="numpy==1.13.3"
-        # pip dependencies to _build_ your project
-        - BUILD_DEPENDS="numpy scipy future"
+        # pip dependencies to _build_ your project. numpy is added later
+        - BUILD_DEPENDS="scipy future"
         # pip dependencies to _test_ your project.  Include any dependencies
         # that you need, that are also specified in BUILD_DEPENDS, this will be
-        # a separate install.
-        - TEST_DEPENDS="numpy scipy future pytest"
+        # a separate install.  numpy is added later
+        - TEST_DEPENDS="scipy future pytest"
         - PLAT=x86_64
         - UNICODE_WIDTH=32
         # BINTRAY_API_KEY

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ matrix:
 
 before_install:
     - BUILD_DEPENDS="$BUILD_DEPENDS $NP_BUILD_DEP"
-    - TEST_DEPENDS="$TEST_DEPENDS $NP_TEST_DEP
+    - TEST_DEPENDS="$TEST_DEPENDS $NP_TEST_DEP"
     - source multibuild/common_utils.sh
     - source multibuild/travis_steps.sh
     - before_install


### PR DESCRIPTION
Otherwise there'll be import errors when using old numpy versions